### PR TITLE
Do not copy languages packages to ProgramData

### DIFF
--- a/CSharp_Engine/CSharp_Engine.csproj
+++ b/CSharp_Engine/CSharp_Engine.csproj
@@ -146,33 +146,6 @@
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
 xcopy "$(TargetDir)*.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
-
-mkdir "C:\ProgramData\BHoM\Assemblies\cs"
-mkdir "C:\ProgramData\BHoM\Assemblies\de"
-mkdir "C:\ProgramData\BHoM\Assemblies\es"
-mkdir "C:\ProgramData\BHoM\Assemblies\fr"
-mkdir "C:\ProgramData\BHoM\Assemblies\it"
-mkdir "C:\ProgramData\BHoM\Assemblies\ja"
-mkdir "C:\ProgramData\BHoM\Assemblies\ko"
-mkdir "C:\ProgramData\BHoM\Assemblies\pl"
-mkdir "C:\ProgramData\BHoM\Assemblies\pt-BR"
-mkdir "C:\ProgramData\BHoM\Assemblies\ru"
-mkdir "C:\ProgramData\BHoM\Assemblies\tr"
-mkdir "C:\ProgramData\BHoM\Assemblies\zh-Hans"
-mkdir "C:\ProgramData\BHoM\Assemblies\zh-Hant"
-
-xcopy "$(TargetDir)\cs\*.dll"  "C:\ProgramData\BHoM\Assemblies\cs" /Y
-xcopy "$(TargetDir)\de\*.dll"  "C:\ProgramData\BHoM\Assemblies\de" /Y
-xcopy "$(TargetDir)\es\*.dll"  "C:\ProgramData\BHoM\Assemblies\es" /Y
-xcopy "$(TargetDir)\fr\*.dll"  "C:\ProgramData\BHoM\Assemblies\fr" /Y
-xcopy "$(TargetDir)\it\*.dll"  "C:\ProgramData\BHoM\Assemblies\it" /Y
-xcopy "$(TargetDir)\ja\*.dll"  "C:\ProgramData\BHoM\Assemblies\ja" /Y
-xcopy "$(TargetDir)\ko\*.dll"  "C:\ProgramData\BHoM\Assemblies\ko" /Y
-xcopy "$(TargetDir)\pl\*.dll"  "C:\ProgramData\BHoM\Assemblies\pl" /Y
-xcopy "$(TargetDir)\pt-BR\*.dll"  "C:\ProgramData\BHoM\Assemblies\pt-BR" /Y
-xcopy "$(TargetDir)\ru\*.dll"  "C:\ProgramData\BHoM\Assemblies\ru" /Y
-xcopy "$(TargetDir)\tr\*.dll"  "C:\ProgramData\BHoM\Assemblies\tr" /Y
-xcopy "$(TargetDir)\zh-Hans\*.dll"  "C:\ProgramData\BHoM\Assemblies\zh-Hans" /Y
-xcopy "$(TargetDir)\zh-Hant\*.dll"  "C:\ProgramData\BHoM\Assemblies\zh-Hant" /Y</PostBuildEvent>
+</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #16

A series of localisation folders are copied over to ProgramData. After a few tests, they didn't look necessary with the current state of the CSharp toolkit. 

So I suggest we drop them for now. I prefer to add them only if they become needed due to new features in the CSharp toolkit.

### Test files
Just make sure that the `ToCSharpText` component is still working once you have deleted those language folders.

You can use this file if you don't have one: https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/CSharp_Toolkit/Node2CodeTest.gh?csf=1&web=1&e=IVWDKG