### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.CSharp.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.CSharp.nuspec
@@ -17,12 +17,11 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.3" />
-        <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.4.0-beta4-final" />
+        <dependency id="Microsoft.CodeAnalysis.CSharp" version="3.4.0" />
         <dependency id="Microsoft.CodeAnalysis.Analyzers" version="2.9.6" />
         <dependency id="ICSharpCode.Decompiler" version="6.2.1.6137" />
-        <dependency id="Humanizer.Core" version="2.2.0" />
         <dependency id="Microsoft.CSharp" version="4.7.0" />
-        <dependency id="System.CodeDom" version="8.0.0-preview.2.23128.3" />
+        <dependency id="System.CodeDom" version="8.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/CSharp_Engine/CSharp_Engine.csproj
+++ b/CSharp_Engine/CSharp_Engine.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.2.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="6.2.1.6137" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.CodeDom" Version="8.0.0-preview.2.23128.3" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
+	<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharp_oM/CSharp_oM.csproj
+++ b/CSharp_oM/CSharp_oM.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #96

- Update Microsoft.CodeAnalysis.CSharp to 3.4.0
- Update System.CodeDom to 8.0.0 (cluster 010)
- Remove Humanizer.Core as not actually used anywhere
- Pin System.Runtime.CompilerServices.Unsafe to 6.1.2 as transient packages were generating a different version

Note that I have kept the wildcard xcopy and didn't pin versions for additional dlls generated in the Build folder for now. 
This will be much easier when we have done a first pass on aligning our direct packages and then compare the versions of dlls produced in the Build folder of each toolkit.


### Test files
Usual testing procedure 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
It might be worth considering removing this repo from the installer since it is not really used by anyone and brings a lot of additional dlls with it.